### PR TITLE
Add oneLineStrip tag to concatenate multiline strings without spaces

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -28,6 +28,7 @@ export default function tags(opts) {
     // replace any newlines with spaces if we just want
     // a one liner
     if (settings.oneLine) temp = temp.replace(/(?:\s+)/g, ' ');
+    if (settings.oneLineTrim) temp = temp.replace(/(?:\n\s+)/g, '');
     if (settings.stripIndent) {
       // strip leading indents
       const match = temp.match(/^[ \t]*(?=\S)/gm);
@@ -48,6 +49,10 @@ export const html = tags({
 
 export const oneLine = tags({
   oneLine: true
+});
+
+export const oneLineTrim = tags({
+  oneLineTrim: true
 });
 
 export const inlineLists = tags({

--- a/readme.md
+++ b/readme.md
@@ -49,6 +49,25 @@ Outputs:
 This is a super crazy long string that will probably exceed our constraint of a maximum of 80 characters in length, and we'd probably have to horizontally scroll our editor if we didn't have ES6 in our utility belt.
 ```
 
+If you want keep your single-line strings under 80 characters while triming the new lines:
+
+```js
+import {oneLineTrim} from 'common-tags';
+let verb = 'crazy';
+console.log(oneLineTrim`
+  https://www.google.fr/search?q=common-tags
+  &oq=common-tags&aqs=chrome..69i57j0l5.1303j0j7
+  &sourceid=chrome&es_sm=91
+  &ie=UTF-8#safe=off&q=common-tags+npm`);
+`);
+```
+
+Outputs:
+
+```
+https://www.google.fr/search?q=common-tags&oq=common-tags&aqs=chrome..69i57j0l5.1303j0j7&sourceid=chrome&es_sm=91&ie=UTF-8#safe=off&q=common-tags+npm`
+```
+
 If you want to strip the annoying indentation from the beginning of each line in a multiline string:
 
 ```js
@@ -140,7 +159,8 @@ I like fruits, but I especially love apples, bananas and kiwi.
 ```js
 {
   trim: true, // trims leading and trailing whitespace
-  oneLine: false, // outputs everything on one line
+  oneLine: false, // outputs everything on one line with 1 space between new lines
+  oneLineTrim: false, // outputs everything on one line without spaces between new lines
   stripIndent: false, // strips leading indents
   includeArrays: false // inlines arrays
 }
@@ -162,6 +182,8 @@ This module also exports aliases for some commonly used combinations:
   - `includeArrays: true`
 - *oneLine*
   - `oneLine: true`
+- *oneLineTrim*
+  - `oneLineTrim: true`
 - *inlineLists*
   - `includeArrays: true`
 - *stripIndent*

--- a/test/index.js
+++ b/test/index.js
@@ -14,6 +14,17 @@ describe('tags', () => {
     `).to.equal('this should be reduced to one line and work with variables');
   });
 
+  it('should strip new lines', () => {
+    const tag = tags({ oneLineTrim: true });
+    const num = 'one';
+    expect(tag`
+      this should be reduced
+      to ${num} line
+      and work with
+      variables
+    `).to.equal('this should be reducedto one lineand work withvariables');
+  });
+
   it('should strip indents', () => {
     const tag = tags({ stripIndent: true });
     const lan = 'en';


### PR DESCRIPTION
This adds a new `oneLineStrip` option and a corresponding tag to allow
multiline strings to be concatenated without any white spaces.`oneLine`
replaces the new lines & indents with a single white space.  However, it
is sometimes needed, e.g. for things like URLs, to not add any white
space but simply trim the new lines & indents.