### PR TITLE
Fix for stripping indent of empty and unindented strings.

### DIFF
--- a/src/stripIndentTransformer/stripIndentTransformer.js
+++ b/src/stripIndentTransformer/stripIndentTransformer.js
@@ -10,6 +10,10 @@ const stripIndentTransformer = (type = 'initial') => ({
     if (type === 'initial') {
       // remove the shortest leading indentation from each line
       const match = endResult.match(/^[ \t]*(?=\S)/gm)
+      // return early if there's nothing to strip
+      if (match === null) {
+        return endResult
+      }
       const indent = Math.min(...match.map(el => el.length))
       const regexp = new RegExp('^[ \\t]{' + indent + '}', 'gm')
       endResult = indent > 0 ? endResult.replace(regexp, '') : endResult

--- a/src/stripIndentTransformer/stripIndentTransformer.test.js
+++ b/src/stripIndentTransformer/stripIndentTransformer.test.js
@@ -26,7 +26,9 @@ test('type "initial" does not remove indents if there is no need to do so', (t) 
     stripIndentTransformer,
     trimResultTransformer
   )
+  t.is(stripIndent``, '')
   t.is(stripIndent`foo`, 'foo')
+  t.is(stripIndent`foo\nbar`, 'foo\nbar')
 })
 
 test('removes all indents if type is "all"', async (t) => {


### PR DESCRIPTION
When stripping the indent of a zero-length string, the error "Cannot read property 'map' of null" would be thrown as the RexExp match is `null`. Added an early exit condition to handle this and similar cases.