### PR TITLE
oneLine preserves spaces within input lines

### DIFF
--- a/src/oneLine/fixtures/oneLine-sentence.txt
+++ b/src/oneLine/fixtures/oneLine-sentence.txt
@@ -1,0 +1,1 @@
+Sentences also work.  Double spacing is preserved.

--- a/src/oneLine/oneLine.js
+++ b/src/oneLine/oneLine.js
@@ -5,7 +5,7 @@ import trimResultTransformer from '../trimResultTransformer'
 import replaceResultTransformer from '../replaceResultTransformer'
 
 const oneLine = new TemplateTag(
-  replaceResultTransformer(/(?:\s+)/g, ' '),
+  replaceResultTransformer(/(?:\n(?:\s*))+/g, ' '),
   trimResultTransformer
 )
 

--- a/src/oneLine/oneLine.test.js
+++ b/src/oneLine/oneLine.test.js
@@ -16,3 +16,12 @@ test('reduces text to one line, replacing newlines with spaces', async (t) => {
   `
   t.is(actual, expected)
 })
+
+test('preserves whitespace within input lines, replacing only newlines', async (t) => {
+  const expected = await readFromFixture('oneLine-sentence')
+  const actual = oneLine`
+    Sentences also work.  Double
+    spacing is preserved.
+  `
+  t.is(actual, expected)
+})


### PR DESCRIPTION
```js
oneLine`
  Preserve eg sentences.  Double
  spaces within input lines.
` === 'Preserve eg sentences.  Double spaces within input lines.'
```

Fix #89