### PR TITLE
Use indexOf instead of String.prototype.includes to support IE

### DIFF
--- a/src/splitStringTransformer/splitStringTransformer.js
+++ b/src/splitStringTransformer/splitStringTransformer.js
@@ -3,7 +3,7 @@
 const splitStringTransformer = (splitBy) => ({
   onSubstitution (substitution, resultSoFar) {
     if (splitBy != null && typeof splitBy === 'string') {
-      if (typeof substitution === 'string' && substitution.includes(splitBy)) {
+      if (typeof substitution === 'string' && substitution.indexOf(splitBy) >= 0) {
         substitution = substitution.split(splitBy)
       }
     } else {


### PR DESCRIPTION
When run in IE the code throws an error since String.prototype.includes does not exist in IE, and it is not transpiled by babel either. Can we switch to use the cross browser compatible `indexOf()` instead?