### PR TITLE
Replace trim methods with RegExp

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -633,7 +633,7 @@ Since `common-tags` is built on the foundation of this TemplateTag class, it com
 
 ##### `trimResultTransformer([side])`
 
-Trims the whitespace surrounding the end result. Accepts an optional `side` (can be `"left"` or `"right"`) that when supplied, will only trim whitespace from that side of the string.
+Trims the whitespace surrounding the end result. Accepts an optional `side` (can be `"start"` or `"end"` or alternatively `"left"` or `"right"`) that when supplied, will only trim whitespace from that side of the string.
 
 
 

--- a/src/oneLine/oneLine.test.js
+++ b/src/oneLine/oneLine.test.js
@@ -17,7 +17,7 @@ test('reduces text to one line, replacing newlines with spaces', async (t) => {
   t.is(actual, expected)
 })
 
-test('reduces text to one line, replacing newlines with spaces', async (t) => {
+test('reduces text to one line, replacing newlines with spaces (no indentation)', async (t) => {
   const expected = await readFromFixture(__dirname, 'oneLine')
   const actual = oneLine`
 wow such doge

--- a/src/oneLineTrim/oneLineTrim.test.js
+++ b/src/oneLineTrim/oneLineTrim.test.js
@@ -16,7 +16,7 @@ test('reduces to one line while trimming newlines', async (t) => {
   t.is(actual, expected)
 })
 
-test('reduces to one line while trimming newlines', async (t) => {
+test('reduces to one line while trimming newlines (no indentation)', async (t) => {
   const expected = await readFromFixture(__dirname, 'oneLineTrim')
   const actual = oneLineTrim`
 wow such reduction

--- a/src/stripIndentTransformer/stripIndentTransformer.js
+++ b/src/stripIndentTransformer/stripIndentTransformer.js
@@ -19,7 +19,7 @@ const stripIndentTransformer = (type = 'initial') => ({
       endResult = indent > 0 ? endResult.replace(regexp, '') : endResult
     } else if (type === 'all') {
       // remove all indentation from each line
-      endResult = endResult.split('\n').map(line => line.trimLeft()).join('\n')
+      endResult = endResult.replace(/(?:\n\s*)/g, '\n')
     } else {
       throw new Error(`Unknown type: ${type}`)
     }

--- a/src/trimResultTransformer/trimResultTransformer.js
+++ b/src/trimResultTransformer/trimResultTransformer.js
@@ -2,19 +2,26 @@
 
 /**
  * TemplateTag transformer that trims whitespace on the end result of a tagged template
- * @param  {String} side = '' - The side of the string to trim. Can be 'left' or 'right'
+ * @param  {String} side = '' - The side of the string to trim. Can be 'start' or 'end' (alternatively 'left' or 'right')
  * @return {Object}           - a TemplateTag transformer
  */
 const trimResultTransformer = (side = '') => ({
   onEndResult (endResult) {
-    side = side.toLowerCase()
-    // uppercase the first letter of side value
-    if (side === 'left' || side === 'right') {
-      side = side.charAt(0).toUpperCase() + side.slice(1)
-    } else if (side !== '') {
-      throw new Error(`Side not supported: ${side}`)
+    if (side === '') {
+      return endResult.trim()
     }
-    return endResult[`trim${side}`]()
+
+    side = side.toLowerCase()
+
+    if (side === 'start' || side === 'left') {
+      return endResult.replace(/^\s*/, '')
+    }
+
+    if (side === 'end' || side === 'right') {
+      return endResult.replace(/\s*$/, '')
+    }
+
+    throw new Error(`Side not supported: ${side}`)
   }
 })
 

--- a/src/trimResultTransformer/trimResultTransformer.test.js
+++ b/src/trimResultTransformer/trimResultTransformer.test.js
@@ -10,9 +10,19 @@ test('trims outer padding', (t) => {
   t.is(trim`  foo  `, 'foo')
 })
 
+test('trims start padding', (t) => {
+  const trimStart = new TemplateTag(trimResultTransformer('start'))
+  t.is(trimStart`  foo  `, 'foo  ')
+})
+
 test('trims left padding', (t) => {
   const trimLeft = new TemplateTag(trimResultTransformer('left'))
   t.is(trimLeft`  foo  `, 'foo  ')
+})
+
+test('trims end padding', (t) => {
+  const trimEnd = new TemplateTag(trimResultTransformer('end'))
+  t.is(trimEnd`  foo  `, '  foo')
 })
 
 test('trims right padding', (t) => {
@@ -26,7 +36,7 @@ test('throws an error if invalid side supplied', (t) => {
 })
 
 test('can be used sequentially', (t) => {
-  const trimLeft = new TemplateTag(stripIndentTransformer, trimResultTransformer('left'))
-  t.is(trimLeft`  foo  `, 'foo  ')
-  t.is(trimLeft`  bar  `, 'bar  ')
+  const trimStart = new TemplateTag(stripIndentTransformer, trimResultTransformer('start'))
+  t.is(trimStart`  foo  `, 'foo  ')
+  t.is(trimStart`  bar  `, 'bar  ')
 })


### PR DESCRIPTION
This PR does two things:
- Add "start" and "end" sides for `trimResultTransformer` - this is in line with string methods already in the standard (like `padStart`/`padEnd`) and with the stage 2 proposal [`trimStart`/`trimEnd`](https://evilpie.github.io/ecmascript-string-left-right-trim/).
- Because `trimLeft`/`trimRight` (or their start/end counterparts) are not yet a part of the standard, they are replaced in the code with regular expressions.