### PR TITLE
make some changes to CI servers for (hopefully) better speed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,7 @@ cache:
 notifications:
   email: true
 node_js:
-  - "6"
-  - "5"
+  - "node"
 script:
   - npm test
 after_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,6 +16,7 @@ test_script:
   - node --version
   - npm --version
   - npm test
+after_test:
   - npm run codecov
 cache:
   - '%APPDATA%\npm-cache'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,6 @@ install:
 matrix:
   fast_finish: true
 build: off
-shallow_clone: true
 test_script:
   - node --version
   - npm --version

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,25 +1,21 @@
-version: "{build}"
 environment:
   matrix:
-    - nodejs_version: "6"
-    - nodejs_version: "5"
-platform:
-  - x86
-  - x64
+    - nodejs_version: 8
+    - nodejs_version: 6
 install:
-  - ps: Install-Product node $env:nodejs_version $env:platform
+  - ps: Install-Product node $env:nodejs_version
   - set CI=true
-  - npm install -g npm@latest || (timeout 30 && npm install -g npm@latest)
+  - npm install --global npm@latest
   - set PATH=%APPDATA%\npm;%PATH%
-  - npm install || (timeout 30 && npm install)
-test_script:
-  # Output useful info for debugging.
-  - node --version && npm --version
-  - cmd: npm test
-build: off
-shallow_clone: true
-clone_depth: 1
+  - npm install
 matrix:
   fast_finish: true
+build: off
+shallow_clone: true
+test_script:
+  - node --version
+  - npm --version
+  - npm test
+  - npm run codecov
 cache:
-  - node_modules -> package.json # local npm modules
+  - '%APPDATA%\npm-cache'


### PR DESCRIPTION
In this PR I've modified both CI servers. Travis now tests the latest stable node release, but not older releases. AppVeyor tests version 8 and version 6 on one core architecture (since I realised there are practically no differences between x86 and x64 in the context of Node.js). This significantly improved build speeds, but I also configured AppVeyor to push test coverage reports as well, and unfortunately this does not support shallow git clones, which slows down performance quite a bit. It however is still an improvement over previous iterations, but not by very much. There is one major benefit though - since Travis speeds have improved marginally, the "time-to-first-byte" so to speak is near instantaneous - it only takes around 1 minute for the result of a CI build to notify the pull request.