### PR TITLE
move babel-runtime to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,10 +14,8 @@
     "Lucian Buzzo (https://github.com/LucianBuzzo)",
     "Rafał Ruciński (https://github.com/fatfisz)"
   ],
-  "dependencies": {
-    "babel-runtime": "^6.26.0"
-  },
   "devDependencies": {
+    "babel-runtime": "^6.26.0",
     "babel-cli": "^6.26.0",
     "babel-eslint": "^8.2.1",
     "babel-plugin-add-module-exports": "^0.2.1",


### PR DESCRIPTION
This would resolve #108 if merged.

This would break very little, as it would mostly only change for people who use the package in a node environment. If you look at this [yarn blog post](https://yarnpkg.com/blog/2018/04/18/dependencies-done-right/#a-tale-of-semantics) (I just remember reading that a few days ago), the devDependencies are only installed if

1. the package is at the top of the dependency tree
1. its dependencies are not installed in production mode

Given that `babel-runtime` is not `import`ed or `require`ed anywhere in the `src`  or `lib` folders (on jsdelivr for the latter), it wouldn't be necessary to include it in the regular dependencies, and have a fairly large library taking up space in people's dependencies when all they want to do is install a cool template tag module. :grin: 