### PR TITLE
Fix substitution evaluation (fixes #143)

### DIFF
--- a/src/TemplateTag/TemplateTag.js
+++ b/src/TemplateTag/TemplateTag.js
@@ -77,7 +77,7 @@ export default class TemplateTag {
       substitutions.shift(),
       resultSoFar,
     );
-    return resultSoFar + substitution + remainingPart;
+    return ''.concat(resultSoFar, substitution, remainingPart);
   }
 
   /**

--- a/src/TemplateTag/TemplateTag.test.js
+++ b/src/TemplateTag/TemplateTag.test.js
@@ -121,3 +121,25 @@ test('supports passing string as a first argument', () => {
   expect(raw).toBe('FOO BAR\n    500');
   expect(onSubstitutionCalls).toBe(0);
 });
+
+test('transforms substitutions to string as per spec', () => {
+  const get = jest
+    .fn()
+    .mockImplementationOnce((target, prop) => {
+      expect(prop).toBe(Symbol.toPrimitive);
+    })
+    .mockImplementationOnce((target, prop) => {
+      expect(prop).toBe('toString');
+    })
+    .mockImplementationOnce((target, prop) => {
+      expect(prop).toBe('valueOf');
+      return () => 42;
+    });
+
+  const val = new Proxy({}, { get });
+  const tag = new TemplateTag();
+  const result = tag`foo ${val} bar`;
+
+  expect(get).toHaveBeenCalledTimes(3);
+  expect(result).toBe('foo 42 bar');
+});


### PR DESCRIPTION
From the [spec](http://www.ecma-international.org/ecma-262/6.0/#sec-template-literals-runtime-semantics-evaluation):
> The string conversion semantics applied to the Expression value are like String.prototype.concat rather than the + operator.

Currently method `processSubstitutions` of `TemplateTag` is concatenating strings using the `+` operator, which results in the default hint while calling [the abstract operation ToPrimitive](http://www.ecma-international.org/ecma-262/6.0/#sec-toprimitive). That causes `valueOf` to be called before `toString` if the value is an object. This is not in line with the spec and caused confusion (#143).

The fix is to simply use `''.concat` (or call String on everything).