### PR TITLE
Add BitMidi to readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -118,6 +118,8 @@ Furthermore, I try to keep this project as transparently stable and updated as f
 - **[stylelint](http://stylelint.io/)** ([ref](https://github.com/stylelint/stylelint/blob/5dc5db5599a00cabc875cf99c56d60f93fbbbd2d/package.json#L82))
 - **[pnpm](https://pnpm.js.org/)** ([ref](https://github.com/pnpm/pnpm/blob/36be3d3f0c75992a1f3ff14b60c99115547d0fcc/package.json#L36))
 - **[jss](http://cssinjs.org/)** ([ref](https://github.com/cssinjs/jss/blob/7b9c1222893495c585b4b61d7ca9af05077cefec/package.json#L44))
+- **[BitMidi](https://bitmidi.com/)** ([ref](https://github.com/feross/bitmidi.com/blob/b6cd24f535eaefcbe472063ad5da8418055d77a2/package.json#L68))
+
 
 ## Installation
 


### PR DESCRIPTION
Add [BitMidi](https://bitmidi.com) to the readme. It uses `common-tags` (see [proof](https://github.com/feross/bitmidi.com/blob/b6cd24f535eaefcbe472063ad5da8418055d77a2/package.json#L68)).

<img width="1085" alt="bitmidi-screenshot" src="https://user-images.githubusercontent.com/121766/45197926-84192600-b218-11e8-9db2-e54cce3c89e3.png">

`common-tags` is super handy!

For context: BitMidi is a historical archive of MIDI files from the early web era. It's a fun way to experience the early web aesthetic of Geocities and Angelfire sites, and also a powerful tool for musicians to find "song stems" to use as the basis for song remixes. It uses the latest modern web technology including WebAssembly and Web Audio to bring MIDI back to life. Learn more here: https://feross.org/bitmidi/