### PR TITLE
Introduce smart trimming

### DIFF
--- a/src/commaLists/commaLists.js
+++ b/src/commaLists/commaLists.js
@@ -1,12 +1,10 @@
 import createTag from '../createTag';
-import stripIndentTransformer from '../stripIndentTransformer';
+import stripIndent from '../stripIndent';
 import inlineArrayTransformer from '../inlineArrayTransformer';
-import trimResultTransformer from '../trimResultTransformer';
 
 const commaLists = createTag(
   inlineArrayTransformer({ separator: ',' }),
-  stripIndentTransformer(),
-  trimResultTransformer(),
+  stripIndent,
 );
 
 export default commaLists;

--- a/src/commaListsAnd/commaListsAnd.js
+++ b/src/commaListsAnd/commaListsAnd.js
@@ -1,12 +1,10 @@
 import createTag from '../createTag';
-import stripIndentTransformer from '../stripIndentTransformer';
+import stripIndent from '../stripIndent';
 import inlineArrayTransformer from '../inlineArrayTransformer';
-import trimResultTransformer from '../trimResultTransformer';
 
 const commaListsAnd = createTag(
   inlineArrayTransformer({ separator: ',', conjunction: 'and' }),
-  stripIndentTransformer(),
-  trimResultTransformer(),
+  stripIndent,
 );
 
 export default commaListsAnd;

--- a/src/commaListsOr/commaListsOr.js
+++ b/src/commaListsOr/commaListsOr.js
@@ -1,12 +1,10 @@
 import createTag from '../createTag';
-import stripIndentTransformer from '../stripIndentTransformer';
+import stripIndent from '../stripIndent';
 import inlineArrayTransformer from '../inlineArrayTransformer';
-import trimResultTransformer from '../trimResultTransformer';
 
 const commaListsOr = createTag(
   inlineArrayTransformer({ separator: ',', conjunction: 'or' }),
-  stripIndentTransformer(),
-  trimResultTransformer(),
+  stripIndent,
 );
 
 export default commaListsOr;

--- a/src/html/html.js
+++ b/src/html/html.js
@@ -1,7 +1,6 @@
 import createTag from '../createTag';
-import stripIndentTransformer from '../stripIndentTransformer';
+import stripIndent from '../stripIndent';
 import inlineArrayTransformer from '../inlineArrayTransformer';
-import trimResultTransformer from '../trimResultTransformer';
 import splitStringTransformer from '../splitStringTransformer';
 import removeNonPrintingValuesTransformer from '../removeNonPrintingValuesTransformer';
 
@@ -9,8 +8,7 @@ const html = createTag(
   splitStringTransformer('\n'),
   removeNonPrintingValuesTransformer(),
   inlineArrayTransformer(),
-  stripIndentTransformer(),
-  trimResultTransformer(),
+  stripIndent,
 );
 
 export default html;

--- a/src/inlineLists/inlineLists.js
+++ b/src/inlineLists/inlineLists.js
@@ -1,12 +1,7 @@
 import createTag from '../createTag';
-import stripIndentTransformer from '../stripIndentTransformer';
+import stripIndent from '../stripIndent';
 import inlineArrayTransformer from '../inlineArrayTransformer';
-import trimResultTransformer from '../trimResultTransformer';
 
-const inlineLists = createTag(
-  inlineArrayTransformer(),
-  stripIndentTransformer(),
-  trimResultTransformer(),
-);
+const inlineLists = createTag(inlineArrayTransformer(), stripIndent);
 
 export default inlineLists;

--- a/src/oneLine/oneLine.test.js
+++ b/src/oneLine/oneLine.test.js
@@ -4,7 +4,7 @@ import { readFromFixture } from '../testUtils';
 const val = 'amaze';
 
 test('reduces text to one line, replacing newlines with spaces', () => {
-  const expected = readFromFixture(__dirname, 'oneLine');
+  const expected = readFromFixture(__dirname, 'oneLine').trim();
   const actual = oneLine`
     wow such doge
     is very ${val}
@@ -15,7 +15,7 @@ test('reduces text to one line, replacing newlines with spaces', () => {
 });
 
 test('reduces text to one line, replacing newlines with spaces (no indentation)', () => {
-  const expected = readFromFixture(__dirname, 'oneLine');
+  const expected = readFromFixture(__dirname, 'oneLine').trim();
   const actual = oneLine`
 wow such doge
 is very ${val}
@@ -27,7 +27,7 @@ from multiline
 });
 
 test('preserves whitespace within input lines, replacing only newlines', () => {
-  const expected = readFromFixture(__dirname, 'oneLine-sentence');
+  const expected = readFromFixture(__dirname, 'oneLine-sentence').trim();
   const actual = oneLine`
     Sentences also work.  Double
     spacing is preserved.

--- a/src/oneLineCommaLists/oneLineCommaLists.test.js
+++ b/src/oneLineCommaLists/oneLineCommaLists.test.js
@@ -5,7 +5,7 @@ const val = 'amaze';
 
 test('includes arrays as comma-separated list on one line', () => {
   const fruits = ['apple', 'banana', 'kiwi'];
-  const expected = readFromFixture(__dirname, 'oneLineCommaLists');
+  const expected = readFromFixture(__dirname, 'oneLineCommaLists').trim();
   const actual = oneLineCommaLists`
     Doge <3's these fruits: ${fruits}
     they are ${val}

--- a/src/oneLineCommaListsAnd/oneLineCommaListsAnd.test.js
+++ b/src/oneLineCommaListsAnd/oneLineCommaListsAnd.test.js
@@ -5,7 +5,7 @@ const val = 'amaze';
 
 test('includes arrays as comma-separated list on one line with "and"', () => {
   const fruits = ['apple', 'banana', 'kiwi'];
-  const expected = readFromFixture(__dirname, 'oneLineCommaListsAnd');
+  const expected = readFromFixture(__dirname, 'oneLineCommaListsAnd').trim();
   const actual = oneLineCommaListsAnd`
     Doge <3's these fruits: ${fruits}
     they are ${val}
@@ -15,7 +15,10 @@ test('includes arrays as comma-separated list on one line with "and"', () => {
 
 test('only returns the first item of a single element array', () => {
   const fruits = ['apple'];
-  const expected = readFromFixture(__dirname, 'oneLineCommaListsAndSingleItem');
+  const expected = readFromFixture(
+    __dirname,
+    'oneLineCommaListsAndSingleItem',
+  ).trim();
   const actual = oneLineCommaListsAnd`
     Doge <3's these fruits: ${fruits}
     they are ${val}

--- a/src/oneLineCommaListsOr/oneLineCommaListsOr.test.js
+++ b/src/oneLineCommaListsOr/oneLineCommaListsOr.test.js
@@ -5,7 +5,7 @@ const val = 'amaze';
 
 test('includes arrays as comma-separated list on one line with "or"', () => {
   const fruits = ['apple', 'banana', 'kiwi'];
-  const expected = readFromFixture(__dirname, 'oneLineCommaListsOr');
+  const expected = readFromFixture(__dirname, 'oneLineCommaListsOr').trim();
   const actual = oneLineCommaListsOr`
     Doge <3's these fruits: ${fruits}
     they are ${val}
@@ -15,7 +15,10 @@ test('includes arrays as comma-separated list on one line with "or"', () => {
 
 test('only returns the first item of a single element array', () => {
   const fruits = ['apple'];
-  const expected = readFromFixture(__dirname, 'oneLineCommaListsOrSingleItem');
+  const expected = readFromFixture(
+    __dirname,
+    'oneLineCommaListsOrSingleItem',
+  ).trim();
   const actual = oneLineCommaListsOr`
     Doge <3's these fruits: ${fruits}
     they are ${val}

--- a/src/oneLineInlineLists/oneLineInlineLists.test.js
+++ b/src/oneLineInlineLists/oneLineInlineLists.test.js
@@ -5,7 +5,7 @@ const val = 'amaze';
 
 test('includes arrays as inline list on one line', () => {
   const fruits = ['apple', 'banana', 'kiwi'];
-  const expected = readFromFixture(__dirname, 'oneLineInlineLists');
+  const expected = readFromFixture(__dirname, 'oneLineInlineLists').trim();
   const actual = oneLineInlineLists`
     Doge <3's these fruits: ${fruits}
     they are ${val}

--- a/src/oneLineTrim/oneLineTrim.test.js
+++ b/src/oneLineTrim/oneLineTrim.test.js
@@ -4,7 +4,7 @@ import { readFromFixture } from '../testUtils';
 const val = 'amaze';
 
 test('reduces to one line while trimming newlines', () => {
-  const expected = readFromFixture(__dirname, 'oneLineTrim');
+  const expected = readFromFixture(__dirname, 'oneLineTrim').trim();
   const actual = oneLineTrim`
   wow such reduction
   very absence of space
@@ -14,7 +14,7 @@ test('reduces to one line while trimming newlines', () => {
 });
 
 test('reduces to one line while trimming newlines (no indentation)', () => {
-  const expected = readFromFixture(__dirname, 'oneLineTrim');
+  const expected = readFromFixture(__dirname, 'oneLineTrim').trim();
   const actual = oneLineTrim`
 wow such reduction
 very absence of space

--- a/src/safeHtml/safeHtml.js
+++ b/src/safeHtml/safeHtml.js
@@ -1,15 +1,13 @@
 import createTag from '../createTag';
-import stripIndentTransformer from '../stripIndentTransformer';
+import stripIndent from '../stripIndent';
 import inlineArrayTransformer from '../inlineArrayTransformer';
-import trimResultTransformer from '../trimResultTransformer';
 import splitStringTransformer from '../splitStringTransformer';
 import replaceSubstitutionTransformer from '../replaceSubstitutionTransformer';
 
 const safeHtml = createTag(
   splitStringTransformer('\n'),
   inlineArrayTransformer(),
-  stripIndentTransformer(),
-  trimResultTransformer(),
+  stripIndent,
   replaceSubstitutionTransformer(/&/g, '&amp;'),
   replaceSubstitutionTransformer(/</g, '&lt;'),
   replaceSubstitutionTransformer(/>/g, '&gt;'),

--- a/src/stripIndent/stripIndent.js
+++ b/src/stripIndent/stripIndent.js
@@ -4,7 +4,7 @@ import trimResultTransformer from '../trimResultTransformer';
 
 const stripIndent = createTag(
   stripIndentTransformer(),
-  trimResultTransformer(),
+  trimResultTransformer('smart'),
 );
 
 export default stripIndent;

--- a/src/stripIndentTransformer/stripIndentTransformer.test.js
+++ b/src/stripIndentTransformer/stripIndentTransformer.test.js
@@ -6,7 +6,7 @@ import { readFromFixture } from '../testUtils';
 test('default behaviour removes the leading indent, but preserves the rest', () => {
   const stripIndent = createTag(
     stripIndentTransformer(),
-    trimResultTransformer(),
+    trimResultTransformer('smart'),
   );
   const expected = readFromFixture(__dirname, 'stripIndent');
   const actual = stripIndent`
@@ -21,7 +21,7 @@ test('default behaviour removes the leading indent, but preserves the rest', () 
 test('type "initial" does not remove indents if there is no need to do so', () => {
   const stripIndent = createTag(
     stripIndentTransformer(),
-    trimResultTransformer(),
+    trimResultTransformer('smart'),
   );
   expect(stripIndent``).toBe('');
   expect(stripIndent`foo`).toBe('foo');
@@ -31,7 +31,7 @@ test('type "initial" does not remove indents if there is no need to do so', () =
 test('removes all indents if type is "all"', () => {
   const stripIndents = createTag(
     stripIndentTransformer('all'),
-    trimResultTransformer(),
+    trimResultTransformer('smart'),
   );
   const expected = readFromFixture(__dirname, 'stripIndents');
   const actual = stripIndents`

--- a/src/stripIndents/stripIndents.js
+++ b/src/stripIndents/stripIndents.js
@@ -4,7 +4,7 @@ import trimResultTransformer from '../trimResultTransformer';
 
 const stripIndents = createTag(
   stripIndentTransformer('all'),
-  trimResultTransformer(),
+  trimResultTransformer('smart'),
 );
 
 export default stripIndents;

--- a/src/testUtils/readFromFixture/readFromFixture.js
+++ b/src/testUtils/readFromFixture/readFromFixture.js
@@ -12,5 +12,5 @@ export default function readFromFixture(dirname, name) {
     path.join(dirname, `fixtures/${name}.txt`),
     'utf8',
   );
-  return contents.replace(/\r\n/g, '\n').trim();
+  return contents.replace(/\r\n/g, '\n');
 }

--- a/src/testUtils/readFromFixture/readFromFixture.test.js
+++ b/src/testUtils/readFromFixture/readFromFixture.test.js
@@ -2,7 +2,7 @@ import readFromFixture from './readFromFixture';
 
 test('reads the correct fixture contents', () => {
   const actual = readFromFixture(__dirname, 'contents');
-  const expected = 'wow such doge';
+  const expected = 'wow such doge\n';
   expect(actual).toBe(expected);
 });
 

--- a/src/trimResultTransformer/trimResultTransformer.js
+++ b/src/trimResultTransformer/trimResultTransformer.js
@@ -1,4 +1,4 @@
-const supportedSides = ['', 'start', 'left', 'end', 'right'];
+const supportedSides = ['', 'start', 'left', 'end', 'right', 'smart'];
 
 /**
  * TemplateTag transformer that trims whitespace on the end result of a tagged template
@@ -23,6 +23,9 @@ const trimResultTransformer = (side = '') => {
         case 'end':
         case 'right':
           return endResult.replace(/\s*$/, '');
+
+        case 'smart':
+          return endResult.replace(/[^\S\n]+$/gm, '').replace(/^\n/, '');
       }
     },
   };

--- a/src/trimResultTransformer/trimResultTransformer.test.js
+++ b/src/trimResultTransformer/trimResultTransformer.test.js
@@ -36,6 +36,34 @@ test('can be used sequentially', () => {
   expect(trimStart`  bar  `).toBe('bar  ');
 });
 
+describe('smart trimming', () => {
+  const trimSmart = createTag(trimResultTransformer('smart'));
+
+  test('leaves a string without surrounding whitespace as-is', () => {
+    expect(trimSmart`a`).toBe('a');
+  });
+
+  test('performs an end-side trim on a single-line string', () => {
+    expect(trimSmart`  a  `).toBe('  a');
+  });
+
+  test('trims whitespace at the end of each line', () => {
+    expect(trimSmart`a  \n  b  \nc  `).toBe('a\n  b\nc');
+  });
+
+  test("removes the first line if it's empty", () => {
+    expect(trimSmart`  \na`).toBe('a');
+  });
+
+  test('leaves the trailing newline character', () => {
+    expect(trimSmart`a  \n`).toBe('a\n');
+  });
+
+  test("doesn't remove intentional newline characters", () => {
+    expect(trimSmart`a\n  \n`).toBe('a\n\n');
+  });
+});
+
 test('throws an error if invalid side supplied', () => {
   expect(() => {
     trimResultTransformer('up');


### PR DESCRIPTION
This should fix the long-standing issue #37.

The rules for "smart trimming" are as such:

- Each line in a string is treated separately, meaning that empty lines won't be removed (with a small exception).
- Whitespace is trimmed at the end of each line.
- The only empty line that will be removed is the very first one, and only if it's empty. That's beacuse of the common pattern of using backticks as parentheses:
    ```js
    const multiLineText = stripIndent`
      foo
      bar
    `;
    ```
    In this case it's safe to assume that the first newline is not wanted in the end result.
- On the other hand the final newline will be left as-is (after trimming the preceeding whitespace). This seems to be a good default, and is actually a long-standing issue #37.

To sum up, smart trimming is about sane defaults and working together with indent-stripping tags.